### PR TITLE
Add support for using auto-tag on orphaned data

### DIFF
--- a/autotag/templates/autotag/auto_tag_init.js.html
+++ b/autotag/templates/autotag/auto_tag_init.js.html
@@ -40,43 +40,60 @@ $(function() {
             // var oid = selected.attr('id');                              // E.g. 'dataset-501'
             // var orel = selected.attr('rel').replace("-locked", "");     // E.g. 'dataset'
 
-            var standby_then_load = function(datasetId) {
+            var standby = function() {
                 // Display waiting message
                 $("div#auto_tag_panel").html('<p class="loading_center">Loading... please wait. <img src ="{% static "webgateway/img/spinner_big.gif" %}"/></p>');
+            };
+
+            var standby_then_load = function(datatype, id) {
+                standby();
                 // Set dataset attribute
-                $("div#auto_tag_panel").attr('rel', 'dataset-' + datasetId);
+                $("div#auto_tag_panel").attr('rel', datatype + '-' + id);
 
                 // Get and load actual contents
-                auto_tag_url = '{% url 'webtagging_index' %}auto_tag/dataset/'+datasetId+'/';
+                auto_tag_url = '{% url 'webtagging_index' %}auto_tag/' + datatype + '/'+id+'/';
                 $("div#auto_tag_panel").load(auto_tag_url);
             };
 
-            var check_same_dataset = function(new_datasetId) {
+            var check_same = function(datatype, id) {
                 // Check if this dataset is already being displayed
                 var crel = $("div#auto_tag_panel").attr('rel');
                 if (crel !== undefined && crel.length > 0 ) {
-                    var cdsId = crel.split("-")[1];
-                    if (cdsId === new_datasetId) {
+                    if (crel === datatype + '-' + id) {
                         return true;
                     }
                 }
                 return false;
             };
 
+            // TODO Make this whole section less clumsy and unreadable. Some refactoring
             var auto_tag_url;
             if (dtype=="image") {
                 var pr = tree_selected.parent().parent();
                 if (pr.length>0) {
-                    var dsId = pr.attr('id').split("-")[1];
+                    if (datatree._get_type(pr) === 'dataset') {
+                        var parentId = pr.attr('id').split("-")[1];
+                        if (check_same('dataset', parentId)) {
+                            //TODO Change selection
+                            return;
+                        }
 
-                    // Check if this dataset is already being displayed
-                    // If so, change selection instead of reloading
-                    if (check_same_dataset(dsId)) {
-                        //TODO Change selection
+                        standby_then_load('dataset', parentId);
+
+                    } else if (datatree._get_type(pr) === 'orphaned') {
+                        var exp = pr.parent().parent();
+                        if (exp.length>0) {
+                            var experimenterId = exp.attr('id').split("-")[1];
+                            if (check_same('orphaned', experimenterId)) {
+                                //TODO Change selection
+                                return;
+                            }
+
+                            standby_then_load('orphaned', experimenterId);
+                        }
+                    } else {
                         return;
                     }
-                    // Otherwise, load is require
-                    standby_then_load(dsId);
                 } else {
                     return;
                 }
@@ -84,17 +101,34 @@ $(function() {
             } else if (dtype=="dataset") {
                 // Check if this dataset is already being displayed
                 // If so, selecting dataset itself equates to no images selected
-                if (check_same_dataset(oid)) {
+                if (check_same('dataset', oid)) {
                     //TODO Change selection to none
                     return;
                 }
-                // Otherwise, load is required
-                standby_then_load(oid);
+
+                standby_then_load('dataset', oid);
+            } else if (dtype == "orphaned") {
+
+                // Get the experimenter that we want orphaned images for
+                var exp = tree_selected.parent().parent();
+                if (exp.length>0) {
+                    console.log(pr);
+                    var experimenterId = exp.attr('id').split("-")[1];
+
+                    if (check_same('orphaned', experimenterId)) {
+                        //TODO Change selection
+                        return;
+                    }
+
+                    standby_then_load('orphaned', experimenterId);
+                }
+
             } else {
                 return;
             }
+
         },
-        supported_obj_types: ['dataset', 'image']
+        supported_obj_types: ['dataset', 'image', 'orphaned']
     });
 });
 

--- a/autotag/templates/autotag/tags_from_names.html
+++ b/autotag/templates/autotag/tags_from_names.html
@@ -52,7 +52,9 @@ $(function(){
         // Not blindly using the current tree selection which
         // could be an image or dataset
         var crel = $("div#auto_tag_panel").attr('rel');
-        var oid = crel.split("-")[1];
+        var crelSplit = crel.split("-");
+        var datatype = crelSplit[0];
+        var oid = crelSplit[1];
 
         var params = "";
         var first = true;
@@ -71,7 +73,7 @@ $(function(){
             }
         }
 
-        var auto_tag_url = "{% url 'webtagging_index' %}auto_tag/dataset/"+oid+'/' + params;
+        var auto_tag_url = "{% url 'webtagging_index' %}auto_tag/" + datatype + "/"+oid+'/' + params;
 
         $("#auto_tag_panel").load(auto_tag_url);
     });

--- a/autotag/urls.py
+++ b/autotag/urls.py
@@ -13,6 +13,8 @@ urlpatterns = patterns('django.views.generic.simple',
 
     # name tokens to tags
     url( r'^auto_tag/dataset/(?P<datasetId>[0-9]+)/$', views.auto_tag, name="webtagging_auto_tag" ),
+    url( r'^auto_tag/orphaned/(?P<experimenterId>[0-9]+)/$', views.auto_tag,
+        name="webtagging_auto_tag_orphaned" ),
 
     # process main form submission
     url( r'^auto_tag/processUpdate/$', views.process_update, name="webtagging_process_update" ),

--- a/autotag/utils.py
+++ b/autotag/utils.py
@@ -116,6 +116,7 @@ class ImageWrapper (omero.gateway.ImageWrapper):
 
 # Update the ref to ImageWrapper in BlitzGateway
 omero.gateway.ImageWrapper = ImageWrapper
+omero.gateway.refreshWrappers()
 
 
 class BlitzSet(object):


### PR DESCRIPTION
Previously, auto-tag would seem to be enabled if selecting an image in the orphaned container, but then error when trying to use it.

auto-tag is now enabled if selecting an image in the orphaned container or the orphaned container itself.

Testing
-----------
- Ensure there is some orphaned data.
- Attempt to use auto-tag when selecting the orphaned container
- Attempt to use auto-tag when selecting an image in the orphaned container

Also, as the code changes may have affected existing functionality:
- Attempt to use auto-tag when selecting the dataset container
- Attempt to use auto-tag when selecting an image in the dataset container

Fixes #11