### PR TITLE
Exclude read only tag when not owner

### DIFF
--- a/autotag/views.py
+++ b/autotag/views.py
@@ -600,12 +600,17 @@ def build_table_data(conn, images, ignoreFirstFileToken=False,
             # Then continue to the next token
             continue
 
-        # Add the matching tags to this token
-        token.add_tags(tags)
+        # Add the matching tags, discarding any that can not be linked
+        # This is when the group is read-only and the querying user is not
+        # the owner of the tag
+        for tag in tags:
+            if tag.canLink():
+                # Add the matching tags to this token
+                token.add_tags([tag])
 
-        # Update the matched_tags in table_data
-        table_data.matched_tags.update(tags)
-        # TODO Do I need to update the all_tags in table_data??
+                # Update the matched_tags in table_data
+                table_data.matched_tags.update([tag])
+                # TODO Do I need to update the all_tags in table_data??
 
     # Find the tags that are prexisting on these images
     for row in table_data.rows:

--- a/autotag/views.py
+++ b/autotag/views.py
@@ -776,7 +776,10 @@ def list_tags(request, conn=None, **kwargs):
 
     tags = []
     for t in conn.getObjects("TagAnnotation"):
-        if t.id not in current_tags:
+        # Exclude tags already in use and tags that are not linkable
+        # because they are in a read-only group of which the current
+        # user is not the owner
+        if t.id not in current_tags and t.canLink():
             tags.append({
                 'id':t.id,
                 'name':t.getTextValue(),


### PR DESCRIPTION
Fixes #21 

In a read-only group, tags are now only offered if owned by the current user in both the token->tax mapping and the new/existing tag dialog.