### PR TITLE
Handle special characters that would not ordinarily be in an ID on a jstree query

### DIFF
--- a/autotag/templates/autotag/tag_table.html
+++ b/autotag/templates/autotag/tag_table.html
@@ -79,7 +79,7 @@
 
                 {% if cell.is_token_cell %}
                     {# Display special case background color for server applied tokens #}
-                    <td class="{{ cell.token.tokentype }}Tokens token_{{ cell.token.value }}{% if cell.is_tagged %} success{% endif %}">
+                    <td class="{{ cell.token.tokentype }}Tokens token_{{ cell.token.css_value }}{% if cell.is_tagged %} success{% endif %}">
 
                         {# Only if this row is annotateable are inputs added #}
                         {% if row.can_annotate %}

--- a/autotag/templates/autotag/tags_from_names.html
+++ b/autotag/templates/autotag/tags_from_names.html
@@ -100,7 +100,7 @@ $(function(){
                     $td.addClass('success');
                     $td.append('<input class="serverselected" name="serverselected" type="hidden" value="tag_' + imageId + '_' + tagId + '"/>');
                 } else {
-                    $td = $('tr#image_' + imageId + ' .token_' + tokenName);
+                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace( /(:|\.|\[|\]|,|;)/g , "\\$1" ));
                     $td.addClass('success');
                     $td.append('<input class="serverselected" name="serverselected" type="hidden" value="token_' + imageId + '_' + tokenName + '"/>');
 
@@ -126,7 +126,7 @@ $(function(){
                     $td.removeClass('success');
                     $td.children('.serverselected').remove();
                 } else {
-                    $td = $('tr#image_' + imageId + ' .token_' + tokenName);
+                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace(/(:|\.|\[|\]|,|;)/g, "\\$1" ));
                     $td.removeClass('success');
                     $td.children('.serverselected').remove();
 

--- a/autotag/templates/autotag/tags_from_names.html
+++ b/autotag/templates/autotag/tags_from_names.html
@@ -100,7 +100,7 @@ $(function(){
                     $td.addClass('success');
                     $td.append('<input class="serverselected" name="serverselected" type="hidden" value="tag_' + imageId + '_' + tagId + '"/>');
                 } else {
-                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace( /(:|\.|\[|\]|,|;)/g , "\\$1" ).replace(" ", "_"));
+                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace( /(:|\.|\[|\]|,|;)/g , "\\$1" ).replace(/ /g, "_"));
                     $td.addClass('success');
                     $td.append('<input class="serverselected" name="serverselected" type="hidden" value="token_' + imageId + '_' + tokenName + '"/>');
 
@@ -126,7 +126,7 @@ $(function(){
                     $td.removeClass('success');
                     $td.children('.serverselected').remove();
                 } else {
-                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace(/(:|\.|\[|\]|,|;)/g, "\\$1" ).replace(" ", "_"));
+                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace(/(:|\.|\[|\]|,|;)/g, "\\$1" ).replace(/ /g, "_"));
                     $td.removeClass('success');
                     $td.children('.serverselected').remove();
 

--- a/autotag/templates/autotag/tags_from_names.html
+++ b/autotag/templates/autotag/tags_from_names.html
@@ -100,7 +100,7 @@ $(function(){
                     $td.addClass('success');
                     $td.append('<input class="serverselected" name="serverselected" type="hidden" value="tag_' + imageId + '_' + tagId + '"/>');
                 } else {
-                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace( /(:|\.|\[|\]|,|;)/g , "\\$1" ));
+                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace( /(:|\.|\[|\]|,|;)/g , "\\$1" ).replace(" ", "_"));
                     $td.addClass('success');
                     $td.append('<input class="serverselected" name="serverselected" type="hidden" value="token_' + imageId + '_' + tokenName + '"/>');
 
@@ -126,7 +126,7 @@ $(function(){
                     $td.removeClass('success');
                     $td.children('.serverselected').remove();
                 } else {
-                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace(/(:|\.|\[|\]|,|;)/g, "\\$1" ));
+                    $td = $('tr#image_' + imageId + ' .token_' + tokenName.replace(/(:|\.|\[|\]|,|;)/g, "\\$1" ).replace(" ", "_"));
                     $td.removeClass('success');
                     $td.children('.serverselected').remove();
 

--- a/autotag/views.py
+++ b/autotag/views.py
@@ -55,6 +55,13 @@ class Token(object):
         """
         self.tokentype = tokentype
 
+    def css_value(self):
+        """
+        Replace spaces with underscore as space is obviously not a valid
+        character for a CSS class
+        """
+        return self.value.replace(' ', '_')
+
 
 class TableHeader(object):
     def __init__(self, parent):


### PR DESCRIPTION
In this case, it was a semicolon, but there are a few other characters that might cause this which need to be escaped when used in a jquery selector. This fixes them all.

Resolves #26 