### PR TITLE
from django.urls import reverse

### DIFF
--- a/tagsearch/omero_webtagging_tagsearch/views.py
+++ b/tagsearch/omero_webtagging_tagsearch/views.py
@@ -3,7 +3,7 @@ from builtins import str
 import json
 import logging
 from django.http import HttpResponse, HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from omeroweb.webclient.decorators import render_response, login_required
 from omero.sys import Parameters


### PR DESCRIPTION
Small change needed to allow running on Django 2.3. See https://github.com/orgs/ome/projects/21.

NB: This change is backwards compatible, supporting current Django 1.11 and Django 2.3

cc @dpwrussell 